### PR TITLE
replace dataLayer variable's script to the top of GTM container

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,7 +97,7 @@ app.use(helmet.contentSecurityPolicy({
 		imgSrc: ["'self'", "data:", "*.addpipe.com"],
 		mediaSrc: ["*.addpipe.com"],
 		objectSrc: ["*.addpipe.com"],
-		scriptSrc: ["'self'", "'unsafe-inline'", "*.addpipe.com", "cdnjs.cloudflare.com", "*.googletagmanager.com"],
+		scriptSrc: ["'self'", "'unsafe-inline'", "*.addpipe.com", "cdnjs.cloudflare.com", "*.googletagmanager.com", "'*.google-analytics.com"],
 		styleSrc: ["'self'", "'unsafe-inline'", "fonts.googleapis.com"]
 	}
 }));

--- a/app.js
+++ b/app.js
@@ -94,7 +94,7 @@ app.use(helmet.contentSecurityPolicy({
 		connectSrc: ["'self'", "api.airtable.com", "cognito-identity.us-east-1.amazonaws.com", "s3.amazonaws.com", "*.addpipe.com", "wss://*.addpipe.com"],
 		fontSrc: ["'self'", "fonts.gstatic.com"],
 		frameSrc: ["'self'", "www.youtube.com"],
-		imgSrc: ["'self'", "data:", "*.addpipe.com", "*.googletagmanager.com"],
+		imgSrc: ["'self'", "data:", "*.addpipe.com", "*.googletagmanager.com", "*.google-analytics.com"],
 		mediaSrc: ["*.addpipe.com"],
 		objectSrc: ["*.addpipe.com"],
 		scriptSrc: ["'self'", "'unsafe-inline'", "*.addpipe.com", "cdnjs.cloudflare.com", "*.googletagmanager.com", "*.google-analytics.com"],

--- a/app.js
+++ b/app.js
@@ -94,10 +94,10 @@ app.use(helmet.contentSecurityPolicy({
 		connectSrc: ["'self'", "api.airtable.com", "cognito-identity.us-east-1.amazonaws.com", "s3.amazonaws.com", "*.addpipe.com", "wss://*.addpipe.com"],
 		fontSrc: ["'self'", "fonts.gstatic.com"],
 		frameSrc: ["'self'", "www.youtube.com"],
-		imgSrc: ["'self'", "data:", "*.addpipe.com"],
+		imgSrc: ["'self'", "data:", "*.addpipe.com", "*.googletagmanager.com"],
 		mediaSrc: ["*.addpipe.com"],
 		objectSrc: ["*.addpipe.com"],
-		scriptSrc: ["'self'", "'unsafe-inline'", "*.addpipe.com", "cdnjs.cloudflare.com", "*.googletagmanager.com", "'*.google-analytics.com"],
+		scriptSrc: ["'self'", "'unsafe-inline'", "*.addpipe.com", "cdnjs.cloudflare.com", "*.googletagmanager.com", "*.google-analytics.com"],
 		styleSrc: ["'self'", "'unsafe-inline'", "fonts.googleapis.com"]
 	}
 }));

--- a/routes/https/error.js
+++ b/routes/https/error.js
@@ -24,7 +24,8 @@ router.get('/', function(req, res, next) {
 		css: css,
 		partials: {
 			body: 'error'
-		}
+		},
+		page: "error"
 	});
 
 });

--- a/routes/https/error.js
+++ b/routes/https/error.js
@@ -22,10 +22,10 @@ router.get('/', function(req, res, next) {
 		description: "Qkids is an online teaching community where thousands of people from the USA and Canada are earning between $16 - $20.00 per hour to teach kids English online.",
 		url: "https://" + req.hostname,
 		css: css,
+		page: "error",
 		partials: {
 			body: 'error'
 		},
-		page: "error"
 	});
 
 });

--- a/routes/https/form.js
+++ b/routes/https/form.js
@@ -22,10 +22,10 @@ router.get('/', function(req, res, next) {
 		description: "Qkids is an online teaching community where thousands of people from the USA and Canada are earning between $16 - $20.00 per hour to teach kids English online.",
 		url: "https://" + req.hostname,
 		css: css,
+		page: "form",
 		partials: {
 			body: 'form'
 		},
-		page: "form"
 	});
 
 });

--- a/routes/https/form.js
+++ b/routes/https/form.js
@@ -24,7 +24,8 @@ router.get('/', function(req, res, next) {
 		css: css,
 		partials: {
 			body: 'form'
-		}
+		},
+		page: "form"
 	});
 
 });

--- a/routes/https/index.js
+++ b/routes/https/index.js
@@ -22,10 +22,10 @@ router.get('/', function(req, res, next) {
 		description: "Qkids is an online teaching community where thousands of people from the USA and Canada are earning between $16 - $20.00 per hour to teach kids English online.",
 		url: "https://" + req.hostname,
 		css: css,
+		page: "home",
 		partials: {
 			body: 'index'
 		},
-		page: "home"
 	});
 
 });

--- a/routes/https/index.js
+++ b/routes/https/index.js
@@ -24,7 +24,8 @@ router.get('/', function(req, res, next) {
 		css: css,
 		partials: {
 			body: 'index'
-		}
+		},
+		page: "home"
 	});
 
 });

--- a/routes/https/mouse.js
+++ b/routes/https/mouse.js
@@ -24,7 +24,8 @@ router.get('/', function(req, res, next) {
 		css: css,
 		partials: {
 			body: 'mouse'
-		}
+		},
+		page: "mouse"
 	});
 
 });

--- a/routes/https/mouse.js
+++ b/routes/https/mouse.js
@@ -22,10 +22,10 @@ router.get('/', function(req, res, next) {
 		description: "Qkids is an online teaching community where thousands of people from the USA and Canada are earning between $16 - $20.00 per hour to teach kids English online.",
 		url: "https://" + req.hostname,
 		css: css,
+		page: "mouse",
 		partials: {
 			body: 'mouse'
 		},
-		page: "mouse"
 	});
 
 });

--- a/routes/https/restore.js
+++ b/routes/https/restore.js
@@ -22,10 +22,10 @@ router.get('/', function(req, res, next) {
 		description: "Qkids is an online teaching community where thousands of people from the USA and Canada are earning between $16 - $20.00 per hour to teach kids English online.",
 		url: "https://" + req.hostname,
 		css: css,
+		name: "restore",
 		partials: {
 			body: 'restore'
 		},
-		name: "restore"
 	});
 
 });

--- a/routes/https/restore.js
+++ b/routes/https/restore.js
@@ -24,7 +24,8 @@ router.get('/', function(req, res, next) {
 		css: css,
 		partials: {
 			body: 'restore'
-		}
+		},
+		name: "restore"
 	});
 
 });

--- a/routes/https/resume.js
+++ b/routes/https/resume.js
@@ -22,10 +22,10 @@ router.get('/', function(req, res, next) {
 		description: "Qkids is an online teaching community where thousands of people from the USA and Canada are earning between $16 - $20.00 per hour to teach kids English online.",
 		url: "https://" + req.hostname,
 		css: css,
+		name: "resume",
 		partials: {
 			body: 'resume'
 		},
-		name: "resume"
 	});
 
 });

--- a/routes/https/resume.js
+++ b/routes/https/resume.js
@@ -24,7 +24,8 @@ router.get('/', function(req, res, next) {
 		css: css,
 		partials: {
 			body: 'resume'
-		}
+		},
+		name: "resume"
 	});
 
 });

--- a/routes/https/thankyou.js
+++ b/routes/https/thankyou.js
@@ -24,7 +24,8 @@ router.get('/', function(req, res, next) {
 		css: css,
 		partials: {
 			body: 'thankyou'
-		}
+		},
+		page: "thankyou"
 	});
 
 });

--- a/routes/https/thankyou.js
+++ b/routes/https/thankyou.js
@@ -22,10 +22,10 @@ router.get('/', function(req, res, next) {
 		description: "Qkids is an online teaching community where thousands of people from the USA and Canada are earning between $16 - $20.00 per hour to teach kids English online.",
 		url: "https://" + req.hostname,
 		css: css,
+		page: "thankyou",
 		partials: {
 			body: 'thankyou'
 		},
-		page: "thankyou"
 	});
 
 });

--- a/routes/https/thankyou2.js
+++ b/routes/https/thankyou2.js
@@ -24,7 +24,8 @@ router.get('/', function(req, res, next) {
 		css: css,
 		partials: {
 			body: 'thankyou2'
-		}
+		},
+		page: "thankyou"
 	});
 
 });

--- a/routes/https/thankyou2.js
+++ b/routes/https/thankyou2.js
@@ -22,10 +22,10 @@ router.get('/', function(req, res, next) {
 		description: "Qkids is an online teaching community where thousands of people from the USA and Canada are earning between $16 - $20.00 per hour to teach kids English online.",
 		url: "https://" + req.hostname,
 		css: css,
+		page: "thankyou",
 		partials: {
 			body: 'thankyou2'
 		},
-		page: "thankyou"
 	});
 
 });

--- a/routes/https/thankyou_skip.js
+++ b/routes/https/thankyou_skip.js
@@ -22,10 +22,10 @@ router.get('/', function(req, res, next) {
 		description: "Qkids is an online teaching community where thousands of people from the USA and Canada are earning between $16 - $20.00 per hour to teach kids English online.",
 		url: "https://" + req.hostname,
 		css: css,
+		page: "thankyou",
 		partials: {
 			body: 'thankyou_skip'
 		},
-		page: "thankyou"
 	});
 
 });

--- a/routes/https/thankyou_skip.js
+++ b/routes/https/thankyou_skip.js
@@ -24,7 +24,8 @@ router.get('/', function(req, res, next) {
 		css: css,
 		partials: {
 			body: 'thankyou_skip'
-		}
+		},
+		page: "thankyou"
 	});
 
 });

--- a/routes/https/video.js
+++ b/routes/https/video.js
@@ -24,7 +24,8 @@ router.get('/', function(req, res, next) {
 		css: css,
 		partials: {
 			body: 'video'
-		}
+		},
+		page: "video"
 	});
 
 });

--- a/routes/https/video.js
+++ b/routes/https/video.js
@@ -22,10 +22,10 @@ router.get('/', function(req, res, next) {
 		description: "Qkids is an online teaching community where thousands of people from the USA and Canada are earning between $16 - $20.00 per hour to teach kids English online.",
 		url: "https://" + req.hostname,
 		css: css,
+		page: "video",
 		partials: {
 			body: 'video'
 		},
-		page: "video"
 	});
 
 });

--- a/views/_frame.hjs
+++ b/views/_frame.hjs
@@ -20,6 +20,18 @@
 		<link rel="stylesheet" href="/css/bootstrap-v4.1.1.css">
 		<link rel="stylesheet" href="/css/clients/main.css">
 
+		<script>
+			//
+			//	The data layer set for Google Tag Manager
+			//
+
+			dataLayer = [{
+				"page": {
+					"type": "{{ page }}"
+				}
+			}];
+		</script>
+
 		<!-- Google Tag Manager -->
 		<script>
 			(function (w, d, s, l, i) {

--- a/views/_frame.hjs
+++ b/views/_frame.hjs
@@ -24,7 +24,6 @@
 			//
 			//	The data layer set for Google Tag Manager
 			//
-
 			dataLayer = [{
 				"page": {
 					"type": "{{ page }}"

--- a/views/error.hjs
+++ b/views/error.hjs
@@ -1,16 +1,3 @@
-<script>
-
-	//
-	//	The data layer set for Google Tag Manager
-	//
-	dataLayer = [{
-		"page": {
-			"type": "error"
-		}
-	}];
-
-</script>
-
 <div class="container marketing">
 
 	<p class="typo-h1 text-center">404 <br> Page not found</p>

--- a/views/form.hjs
+++ b/views/form.hjs
@@ -1,15 +1,6 @@
 <script>
 
 	//
-	//	The data layer set for Google Tag Manager
-	//
-	dataLayer = [{
-		"page": {
-			"type": "form"
-		}
-	}];
-
-	//
 	//	Check to see if we have the state, by default the state is only
 	//	available if the session was restored from a URL.
 	//

--- a/views/index.hjs
+++ b/views/index.hjs
@@ -1,16 +1,3 @@
-<script>
-
-	//
-	//	The data layer set for Google Tag Manager
-	//
-	dataLayer = [{
-		"page": {
-			"type": "home"
-		}
-	}];
-
-</script>
-
 <!-- Banner section -->
 <section class="home-banner-section">
 	<div class="container">

--- a/views/mouse.hjs
+++ b/views/mouse.hjs
@@ -1,16 +1,3 @@
-<script>
-
-    //
-    //  The data layer set for Google Tag Manager
-    //
-	dataLayer = [{
-		"page": {
-			"type": "mouse"
-		}
-	}];
-
-</script>
-
 <div class="example-section">
     <div class="container">
         <h1 class="typo-h1 text-violet text-center">A Town Mouse and A Country Mouse</h1>

--- a/views/restore.hjs
+++ b/views/restore.hjs
@@ -1,16 +1,3 @@
-<script>
-
-	//
-	//	The data layer set for Google Tag Manager
-	//
-	dataLayer = [{
-		"page": {
-			"type": "restore"
-		}
-	}];
-
-</script>
-
 <div id="loader-wrapper">
 	<div id="loader"></div>
 </div>

--- a/views/resume.hjs
+++ b/views/resume.hjs
@@ -1,15 +1,6 @@
 <script>
 
 	//
-	//	The data layer set for Google Tag Manager
-	//
-	dataLayer = [{
-		"page": {
-			"type": "resume"
-		}
-	}];
-
-	//
 	//	Check to see if we the user submited already a resume and if so we skip
 	//	this page.
 	//

--- a/views/thankyou.hjs
+++ b/views/thankyou.hjs
@@ -1,16 +1,3 @@
-<script>
-
-	//
-	//	The data layer set for Google Tag Manager
-	//
-	dataLayer = [{
-		"page": {
-			"type": "thankyou"
-		}
-	}];
-
-</script>
-
 <div class="register-register-section">
 	<div class="container">
 		<div class="card-block register-card">

--- a/views/thankyou2.hjs
+++ b/views/thankyou2.hjs
@@ -1,16 +1,3 @@
-<script>
-
-	//
-	//	The data layer set for Google Tag Manager
-	//
-	dataLayer = [{
-		"page": {
-			"type": "thankyou"
-		}
-	}];
-
-</script>
-
 <div class="register-register-section">
 	<div class="container">
 		<div class="card-block register-card">

--- a/views/thankyou_skip.hjs
+++ b/views/thankyou_skip.hjs
@@ -1,17 +1,3 @@
-<script>
-
-	//
-	//	The data layer set for Google Tag Manager
-	//
-	dataLayer = [{
-		"page": {
-			"type": "thankyou"
-		}
-	}];
-
-</script>
-
-
 <div class="register-register-section">
 	<div class="container">
 		<div class="card-block register-card">

--- a/views/video.hjs
+++ b/views/video.hjs
@@ -1,15 +1,6 @@
 <script>
 
 	//
-	//	The data layer set for Google Tag Manager
-	//
-	dataLayer = [{
-		"page": {
-			"type": "video"
-		}
-	}];
-
-	//
 	//	Check to see if the video was already submitted, and if so we skip
 	//	this page and go to the next one,
 	//


### PR DESCRIPTION
Data layer needs to be above the container snippet. Variables pushed to the data layer after the container snippet will not be able to fire tags on page loads with a matching condition.